### PR TITLE
Remove naming convention dependency where possible

### DIFF
--- a/PHPUnitStandard/Sniffs/Testing/ClassNameSniff.php
+++ b/PHPUnitStandard/Sniffs/Testing/ClassNameSniff.php
@@ -27,7 +27,14 @@ implements PHP_CodeSniffer_Sniff {
         $origStackPtr = $stackPtr;
 
         $filename = $phpcsFile->getFileName();
-        preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches);
+        if(!preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches)) {
+            $phpcsFile->addWarning(
+                'File path does not match expected convention.',
+                $stackPtr
+            );
+            return;
+        }
+        
         $expected = str_replace("/", "_", $matches[1]);
 
         $found = array();

--- a/PHPUnitStandard/Sniffs/Testing/ExtraneousClassSniff.php
+++ b/PHPUnitStandard/Sniffs/Testing/ExtraneousClassSniff.php
@@ -25,7 +25,13 @@ implements PHP_CodeSniffer_Sniff {
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
         $filename = $phpcsFile->getFileName();
-        preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches);
+        if(!preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches)) {
+            $phpcsFile->addWarning(
+                'Filepath does not match expected convention',
+                $stackPtr
+            );
+            return;
+        }
         $expected = str_replace("/", "_", $matches[1]);
 
         $declarationName = $phpcsFile->getDeclarationName($stackPtr);

--- a/PHPUnitStandard/Sniffs/Testing/ProvenTestCaseSniff.php
+++ b/PHPUnitStandard/Sniffs/Testing/ProvenTestCaseSniff.php
@@ -33,15 +33,7 @@ implements PHP_CodeSniffer_Sniff {
      * @return void
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
-        $filename = $phpcsFile->getFileName();
-        preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches);
-        $expected = str_replace("/", "_", $matches[1]);
-
         $declarationName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($declarationName != $expected) {
-            return;
-        }
-
         $extendedClassName = $phpcsFile->findExtendedClassName($stackPtr);
         if (!($extendedClassName
             && in_array($extendedClassName, $this->classNameWhitelist))

--- a/PHPUnitStandard/Sniffs/Testing/TestOrProviderFunctionsOnlySniff.php
+++ b/PHPUnitStandard/Sniffs/Testing/TestOrProviderFunctionsOnlySniff.php
@@ -24,16 +24,8 @@ implements PHP_CodeSniffer_Sniff {
      * @return void
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
-        $filename = $phpcsFile->getFileName();
-        preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches);
-        $expected = str_replace("/", "_", $matches[1]);
-
         $classStackPtr = $phpcsFile->findPrevious(T_CLASS, $stackPtr);
         $className = $phpcsFile->getDeclarationName($classStackPtr);
-        if ($className != $expected) {
-            return;
-        }
-
         $properties = $phpcsFile->getMethodProperties($stackPtr);
         $functionName = $phpcsFile->getDeclarationName($stackPtr);
         if (!in_array($properties['scope'], array('private', 'protected'))) {

--- a/PHPUnitStandard/Sniffs/Testing/TestOrProviderIsPublicSniff.php
+++ b/PHPUnitStandard/Sniffs/Testing/TestOrProviderIsPublicSniff.php
@@ -24,16 +24,8 @@ implements PHP_CodeSniffer_Sniff {
      * @return void
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
-        $filename = $phpcsFile->getFileName();
-        preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches);
-        $expected = str_replace("/", "_", $matches[1]);
-
         $classStackPtr = $phpcsFile->findPrevious(T_CLASS, $stackPtr);
         $className = $phpcsFile->getDeclarationName($classStackPtr);
-        if ($className != $expected) {
-            return;
-        }
-
         $properties = $phpcsFile->getMethodProperties($stackPtr);
         $functionName = $phpcsFile->getDeclarationName($stackPtr);
         if (in_array($properties['scope'], array('private', 'protected'))) {

--- a/PHPUnitStandard/Sniffs/Testing/UnusedProviderSniff.php
+++ b/PHPUnitStandard/Sniffs/Testing/UnusedProviderSniff.php
@@ -24,15 +24,8 @@ implements PHP_CodeSniffer_Sniff {
      * @return void
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
-        $filename = $phpcsFile->getFileName();
-        preg_match("@.*/tests/phpunit/(.*).php@", $filename, $matches);
-        $expected = str_replace("/", "_", $matches[1]);
-
         $classStackPtr = $phpcsFile->findPrevious(T_CLASS, $stackPtr);
         $className = $phpcsFile->getDeclarationName($classStackPtr);
-        if ($className != $expected) {
-            return;
-        }
 
         $functionName = $phpcsFile->getDeclarationName($stackPtr);
         if (!preg_match('@provide[A-Z_].*@', $functionName)) {


### PR DESCRIPTION
When first running your sniffs i was running into A LOT of errors like this one:

> Notice: Undefined offset: 1 in /home/edo/Desktop/PHP/phpunit-dev/PHPUnit-CodeSniffer/PHPUnitStandard/Sniffs/Testing/TestOrProviderIsPublicSniff.php on line 29

That happens because the coding standard expects the tests to be 'Zend underscore style' named in `tests/phpunit`.

Our tests are located in .../tests/unit/.. (as in sebastians bankaccount example) so it didn't work out and since it was not checked if the preg_match matched it lead to the notices.

If've tried to clean this up a little bit without breaking anything or removing behavior.

Should you decide to pull this I'd add a "only one class per file" rule just for good measure and to make sure the other sniffs still work well.
